### PR TITLE
Relax upper bound on dependencies to support newer discord-haskell

### DIFF
--- a/discord-haskell-voice.cabal
+++ b/discord-haskell-voice.cabal
@@ -49,27 +49,28 @@ library
       src
   default-extensions:
       OverloadedStrings
+    , Strict
   build-depends:
       BoundedChan ==1.0.3.0
-    , aeson >=1.5 && <1.6 || >=2.0 && <2.2
+    , aeson >=1.5 && <1.6 || >=2.0 && <2.3
     , async >=2.2.3 && <2.4
     , base >=4.7 && <5
     , binary ==0.8.*
-    , bytestring >=0.10.12.0 && <0.12
+    , bytestring >=0.10.12.0 && <0.13
     , conduit >=1.3.4.2 && <=1.4.0.0
     , conduit-extra ==1.3.6
-    , discord-haskell >=1.12.0 && <=1.15.3
+    , discord-haskell >=1.12.0 && <=1.17.1
     , microlens >=0.4.11.2
     , microlens-th >=0.4.3.10
-    , mtl ==2.2.2
+    , mtl < 2.4
     , network >=3.1.1.1 && <3.2
     , opus ==0.3.0.0
     , safe-exceptions >=0.1.7.1 && <0.1.8
     , stm >=2.5.0.0 && <=2.6.0.0
-    , text >=1.2.4.1 && <2
+    , text >=1.2.4.1 && <3
     , time >=1.9.3 && <=1.13
     , unliftio >=0.2.18 && <0.3
-    , websockets >=0.12.7.2 && <0.12.8
+    , websockets >=0.12.7.2 && <0.14
     , wuss >=1.1.18 && <2.1.0.0
   default-language: Haskell2010
   if flag(use-shecretbox)
@@ -79,7 +80,7 @@ library
       , shecretbox ==0.0.1
   else
     build-depends:
-        saltine >=0.1.1.1 && <0.3
+        saltine >=0.1.1.1 && <0.4
 
 executable basic-music-bot
   main-is: examples/BasicMusicBot.hs
@@ -91,12 +92,12 @@ executable basic-music-bot
   build-depends:
       base >=4.7 && <5
     , conduit >=1.3.4.2 && <=1.4.0.0
-    , discord-haskell >=1.12.0 && <=1.15.3
+    , discord-haskell >=1.12.0 && <=1.17.1
     , discord-haskell-voice
     , optparse-applicative >=0.15.1.0 && <0.18
     , stm >=2.5.0.0 && <2.6
-    , stm-containers ==1.2
-    , text >=1.2.4.1 && <2
+    , stm-containers < 1.4
+    , text >=1.2.4.1 && <3
     , unliftio >=0.2.18 && <0.3
   default-language: Haskell2010
 
@@ -110,8 +111,8 @@ executable join-all-on-start
   build-depends:
       base >=4.7 && <5
     , conduit >=1.3.4.2 && <=1.4.0.0
-    , discord-haskell >=1.12.0 && <=1.15.3
+    , discord-haskell >=1.12.0 && <=1.17.1
     , discord-haskell-voice
     , safe-exceptions >=0.1.7.1 && <0.1.8
-    , text >=1.2.4.1 && <2
+    , text >=1.2.4.1 && <3
   default-language: Haskell2010


### PR DESCRIPTION
Relaxes the upper bound on dependencies to support the newer versions of discord-haskell.

We also bump other dependencies where necessary so that we can easily support GHC 9.10 once discord-haskell has its Hackage release supporting it. With this PR, the project can already build on GHC 9.10 if you use the latest git HEAD for discord-haskell instead of the Hackage version.