### PR TITLE
Update copyright across all modules and package descriptions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021-2022 Yuto Takano
+Copyright (c) 2025-PRESENT discord-haskell-voice Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/discord-haskell-voice.cabal
+++ b/discord-haskell-voice.cabal
@@ -11,9 +11,9 @@ description:    Supplementary library to discord-haskell. See the project README
 category:       Network
 homepage:       https://github.com/yutotakano/discord-haskell-voice#readme
 bug-reports:    https://github.com/yutotakano/discord-haskell-voice/issues
-author:         Yuto Takano
-maintainer:     moa17stock@gmail.com
-copyright:      2021-2022 Yuto Takano
+author:         Yuto Takano <moa17stock@gmail.com>
+maintainer:     Yuto Takano <moa17stock@gmail.com>
+copyright:      Yuto Takano <moa17stock@gmail.com>, discord-haskell-voice Contributors
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -6,9 +6,9 @@ description:         Supplementary library to discord-haskell.
 synopsis:            Voice support for discord-haskell.
 github:              "yutotakano/discord-haskell-voice"
 license:             MIT
-author:              Yuto Takano
-maintainer:          "moa17stock@gmail.com"
-copyright:           "2021-2022 Yuto Takano"
+author:              Yuto Takano <moa17stock@gmail.com>
+maintainer:          Yuto Takano <moa17stock@gmail.com>
+copyright:           Yuto Takano <moa17stock@gmail.com>, discord-haskell-voice Contributors
 category:            Network
 extra-source-files:
 - README.md

--- a/src/Discord/Internal/Types/VoiceCommon.hs
+++ b/src/Discord/Internal/Types/VoiceCommon.hs
@@ -9,8 +9,9 @@
 Module      : Discord.Internal.Types.VoiceCommon
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Types/VoiceUDP.hs
+++ b/src/Discord/Internal/Types/VoiceUDP.hs
@@ -4,8 +4,9 @@
 Module      : Discord.Internal.Types.VoiceUDP
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Types/VoiceWebsocket.hs
+++ b/src/Discord/Internal/Types/VoiceWebsocket.hs
@@ -5,8 +5,9 @@
 Module      : Discord.Internal.Types.VoiceWebsocket
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Voice.hs
+++ b/src/Discord/Internal/Voice.hs
@@ -4,8 +4,9 @@
 Module      : Discord.Internal.Voice
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Voice/CommonUtils.hs
+++ b/src/Discord/Internal/Voice/CommonUtils.hs
@@ -4,8 +4,9 @@
 Module      : Discord.Internal.Voice.CommonUtils
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Voice/Encryption.hs
+++ b/src/Discord/Internal/Voice/Encryption.hs
@@ -4,8 +4,9 @@
 Module      : Discord.Internal.Voice.Encryption
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Voice/OggParser.hs
+++ b/src/Discord/Internal/Voice/OggParser.hs
@@ -1,6 +1,29 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-|
+Module      : Discord.Internal.Voice.OggParser
+Description : Strictly for internal use only. See Discord.Voice for the public interface.
+Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
+License     : MIT
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
+
+= WARNING
+
+This module is considered __internal__.
+
+The Package Versioning Policy __does not apply__.
+
+The contents of this module may change __in any way whatsoever__ and __without__
+__any warning__ between minor versions of this package.
+
+= Description
+
+This module provides @unwrapOggPacketsC@, a conduit that unwraps Ogg packets
+from a stream of bytes, and extracts the Opus packets from them. This is used
+to parse FFmpeg's Ogg output into Opus packets that can be sent to Discord.
+-}
 module Discord.Internal.Voice.OggParser
     ( unwrapOggPacketsC
     ) where

--- a/src/Discord/Internal/Voice/UDPLoop.hs
+++ b/src/Discord/Internal/Voice/UDPLoop.hs
@@ -3,8 +3,9 @@
 Module      : Discord.Internal.Voice.UDPLoop
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Internal/Voice/WebsocketLoop.hs
+++ b/src/Discord/Internal/Voice/WebsocketLoop.hs
@@ -5,8 +5,9 @@
 Module      : Discord.Internal.Voice.WebsocketLoop
 Description : Strictly for internal use only. See Discord.Voice for the public interface.
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 = WARNING
 

--- a/src/Discord/Voice.hs
+++ b/src/Discord/Voice.hs
@@ -2,8 +2,9 @@
 Module      : Discord.Voice
 Description : Voice support for discord-haskell!
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 Welcome to @discord-haskell-voice@! This library provides you with a high-level
 interface for interacting with Discord's Voice API, building on top of the

--- a/src/Discord/Voice/Conduit.hs
+++ b/src/Discord/Voice/Conduit.hs
@@ -4,8 +4,9 @@
 Module      : Discord.Voice.Conduit
 Description : Convenient Conduits for transforming voice data
 Copyright   : (c) 2021-2022 Yuto Takano
+              (c) 2025-PRESENT discord-haskell-voice Contributors
 License     : MIT
-Maintainer  : moa17stock@gmail.com
+Maintainer  : Yuto Takano <moa17stock@gmail.com>
 
 This module provides convenient Conduits (see the @conduit@ package for an
 introduction to conduits, but essentially streaming pipes) for transforming


### PR DESCRIPTION
- Added `2025-PRESENT discord-haskell-voice Contributors` to all places that listed the project copyright
- Also added OggParser's module Haddock since it was missing
- Fixes #34 