### PR TITLE
Fix subtle possibilities of voice artifacts due to encoding errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@
   - Fix `OpusBufferTooSmall` when receiving Opus data due to buffer being half the size it should be
   - Fix the library crashing when joining a call with another user already in it, which triggers Opcodes 11/18/20 before Opcode 4
   - Fix `leave` causing MVar thread deadlock due to the BoundedChan consumer thread being killed
+  - Fix possibility of audio artifacts when sending multiple audio resources back-to-back due to incorrect silence frames [#45](https://github.com/yutotakano/discord-haskell-voice/pull/45)
+  - Fix posibility of the last few bytes of Opus frames being cut off during transmission due to a buffer too small [#45](https://github.com/yutotakano/discord-haskell-voice/pull/45)
 
 - Miscellaneous
   - Support GHC 8.10.7, 9.0.2, 9.2.4, and 9.6.6

--- a/src/Discord/Internal/Voice.hs
+++ b/src/Discord/Internal/Voice.hs
@@ -553,8 +553,18 @@ encodeOpusC = chunksOfCE (48*20*2*2) .| do
     loop encoder
   where
     enCfg = mkEncoderConfig opusSR48k True app_audio
-    -- 1275 is the max bytes an opus 20ms frame can have
-    streamCfg = mkStreamConfig enCfg (48*20) 1276
+
+    -- 48kHz means that 1s has 48,000 samples (or 96,000 for stereo). Therefore,
+    -- 1ms has 48 samples. An opus frame is 20ms (by default), so it has
+    -- 48 * 20 samples (or 48 * 20 * 2 for stereo).
+    -- Each sample has 2 bytes of precision (16 bits), so the size of a frame
+    -- is 48 * 20 * 2 (or double for stereo). libopus, per its docs, wants a
+    -- per-channel frame size in the unit of "number of samples", so we use
+    -- 48 * 20 as the input.
+    --
+    -- For the output buffer size, 1275 is the max bytes an opus 20ms frame can
+    -- have, + the largest possible Opus packet header size is 7 bytes.
+    streamCfg = mkStreamConfig enCfg (48 * 20) (1275 + 7)
     loop encoder = await >>= \case
         Nothing -> do
             -- Send at least 5 blank frames (20ms * 5 = 100 ms)


### PR DESCRIPTION
Fixes two issues with audio transmission:
- The output buffer size for opus encoding was set to 1276, which is theoretically not enough, since a maximum of 7 bytes of Opus header can be attached to a maximum of 1275 bytes of audio.
  - The fix is to increase the output buffer size to 1275 +  7. 
- Discord requires us to send 5 blank silence frames after audio transmission to prevent Opus interpolation artifacts on the next stream. We were treating [0xF8, 0xFF, 0xFE] as PCM and encrypted it via Opus, but this is in fact the representation of an Opus-encoded silence 20ms frame already. 
  - The fix is to send [0xF8, 0xFF, 0xFE] five times as-is instead of trying to encode it again via Opus.