### PR TITLE
Fix 'bad object' error in Renovate CI due to shallow history

### DIFF
--- a/.github/workflows/build_cabal.yml
+++ b/.github/workflows/build_cabal.yml
@@ -32,6 +32,15 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          # Default is 1 (only one commit) but in order to do git log on PRs and
+          # get the PR head commit, we need more history -- so we set it to 0
+          # (unlimited).
+          #
+          # The PR head commit on a pull_request event is not the most recent
+          # commit, since GitHub Actions performs a merge onto the base branch
+          # and runs CI on the result.
+          fetch-depth: 0
 
       - name: Install LLVM 12 for 8.10.7 and 9.0.2 on macOS
         if: ${{ matrix.os == 'macOS-latest' && (matrix.ghc == '8.10.7' || matrix.ghc == '9.0.2') }}


### PR DESCRIPTION
The checkout action by default only checks out one single commit.

On a 'pull_request' CI trigger, the most recent single commit refers to a 'ghost' ephemeral commit created within the CI environment that is the result of merging the PR onto the base branch. Thus, if we try to get information about the PR head commit (such as its Git trailer message from Renovate), we get a 'bad object' error.

We fix it by setting fetch-depth to 0 (unlimited) in the checkout action, which is the same thing done in [pureMD5](https://github.com/haskell-github-trust/pureMD5/commit/dc68e032ddb71051a26a6d26849183d655856f63).