### PR TITLE
Depdencies: Move from cryptonite to crypton & fix GHC 9.6 errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,7 +27,7 @@
   - Improve BasicMusicBot example to be less lisp-y in terms of brackets, and fix all warnings
   - Improve error messages when parsing Ogg containers fail
   - Use `DerivingStrategies` in the library code to make explicit where deriving typeclasses are from
-  - Add a compile flag to use a `crypton`-based encryption backend, which removes the necessity for libsodium
+  - Add a compile flag (`-use-crypton`) to use a `crypton`-based encryption backend, which removes the necessity for libsodium
   - Remove `containers` dependency
   - Relax package bounds:
     - `aeson` from ==1.5.6.0 to <2.3

--- a/discord-haskell-voice.cabal
+++ b/discord-haskell-voice.cabal
@@ -81,7 +81,13 @@ library
       , crypton-box >=1.1.0 && <1.2
   else
     build-depends:
-        saltine >=0.1.1.1 && <0.4
+        saltine >=0.1.1.1 && <0.3
+
+  if impl(ghc >= 9.6)
+    -- 1.15.5 and earlier cannot build on GHC >= 9.6 since it tries to import
+    -- Control.Monad functions from Control.Monad.Reader
+    build-depends:
+        discord-haskell  >= 1.15.6
 
 executable basic-music-bot
   main-is: examples/BasicMusicBot.hs

--- a/discord-haskell-voice.cabal
+++ b/discord-haskell-voice.cabal
@@ -62,7 +62,7 @@ library
     , discord-haskell >=1.12.0 && <=1.17.1
     , microlens >=0.4.11.2
     , microlens-th >=0.4.3.10
-    , mtl < 2.4
+    , mtl <2.4
     , network >=3.1.1.1 && <3.2
     , opus ==0.3.0.0
     , safe-exceptions >=0.1.7.1 && <0.1.8
@@ -77,8 +77,8 @@ library
   if flag(use-crypton)
     cpp-options: -DUSE_CRYPTON
     build-depends:
-        cryptonite >=0.29
-      , shecretbox ==0.0.1
+        crypton >=0.32 && <1.1
+      , crypton-box >=1.1.0 && <1.2
   else
     build-depends:
         saltine >=0.1.1.1 && <0.4

--- a/discord-haskell-voice.cabal
+++ b/discord-haskell-voice.cabal
@@ -25,8 +25,8 @@ source-repository head
   type: git
   location: https://github.com/yutotakano/discord-haskell-voice
 
-flag use-shecretbox
-  description: Use Shecretbox, a Haskell implementation of secretbox encryption, powered using cryptonite. If off, requires libsodium to dynamically link to.
+flag use-crypton
+  description: Use crypton and crypton-box libraries for encryption instead of saltine, which has a dependency on libsodium. While it may be tempting to use a "pure-Haskell" solution (crypton does have a lot of C though), crypton and crypton-box's security have not been vetted for attacks. Further, Discord themselves use libsodium in their infrastructure, so it's recommended to keep this flag off and use saltine.
   manual: True
   default: False
 
@@ -73,8 +73,9 @@ library
     , websockets >=0.12.7.2 && <0.14
     , wuss >=1.1.18 && <2.1.0.0
   default-language: Haskell2010
-  if flag(use-shecretbox)
-    cpp-options: -DUSE_SHECRETBOX
+
+  if flag(use-crypton)
+    cpp-options: -DUSE_CRYPTON
     build-depends:
         cryptonite >=0.29
       , shecretbox ==0.0.1

--- a/src/Discord/Internal/Voice/Encryption.hs
+++ b/src/Discord/Internal/Voice/Encryption.hs
@@ -27,7 +27,7 @@ module Discord.Internal.Voice.Encryption
     ( module Discord.Internal.Voice.Encryption
     ) where
 
-#ifdef USE_SHECRETBOX
+#ifdef USE_CRYPTON
 import Crypto.PubKey.Curve25519 qualified as X25519
 import Crypto.SecretBox qualified as SecretBox
 import Crypto.Error ( maybeCryptoError )
@@ -51,10 +51,10 @@ import Data.Word ( Word8 )
 -- This does no error handling on misformatted key/nonce since this function is
 -- only used in contexts where we are guaranteed they are valid.
 --
--- When USE_SHECRETBOX is defined (using the use-shecretbox flag), the function
+-- When USE_CRYPTON is defined (using the use-crypton flag), the function
 -- is implemented as a wrapper for the 'SecretBox.open' function.
 decrypt :: [Word8] -> B.ByteString -> B.ByteString -> Maybe B.ByteString
-#ifdef USE_SHECRETBOX
+#ifdef USE_CRYPTON
 decrypt byteKey nonce ciphertext = SecretBox.open ciphertext nonce key
   where
     key = fromJust $ maybeCryptoError $ X25519.dhSecret $ B.pack byteKey
@@ -72,10 +72,10 @@ decrypt byteKey byteNonce og = secretboxOpen key nonce og
 -- As with decryption, this function does no error handling on the format of the
 -- key and nonce (key = 32 bytes, nonce = 24 bytes).
 --
--- When USE_SHECRETBOX is defined (using the use-shecretbox flag), the function
+-- When USE_CRYPTON is defined (using the use-crypton flag), the function
 -- is implemented as a warpper for the 'SecretBox.create' function.
 encrypt :: [Word8] -> B.ByteString -> B.ByteString -> B.ByteString
-#ifdef USE_SHECRETBOX
+#ifdef USE_CRYPTON
 encrypt byteKey nonce message = SecretBox.create message nonce key
   where
     key = fromJust $ maybeCryptoError $ X25519.dhSecret $ B.pack byteKey


### PR DESCRIPTION
- Move from `cryptonite` and `shecretbox` to `crypton` and `crypton-box` since the former is deprecated and no longer maintained.
  - Accordingly, the compile flags have been renamed
- Fixes a compilation error on GHC versions 9.6 and above since discord-haskell below 1.15.5 was trying to import Control.Monad entities from Control.Monad.Reader, which used to work but is now not possible
  - We handled this by a conditional lower bound, so old versions of GHC and discord-haskell remain supported