### PR TITLE
Add docs on forking when running runVoice

### DIFF
--- a/src/Discord/Internal/Types/VoiceCommon.hs
+++ b/src/Discord/Internal/Types/VoiceCommon.hs
@@ -71,7 +71,7 @@ import Discord.Internal.Types.VoiceWebsocket
 -- that might fit the library!
 newtype Voice a = Voice
     { unVoice :: ReaderT DiscordBroadcastHandle DiscordHandler a
-    } deriving newtype
+    } deriving newtype -- we use the newtype strategy so it's mostly ReaderT
     ( Functor
     , Applicative
     , Monad
@@ -79,6 +79,12 @@ newtype Voice a = Voice
     -- ^ MonadIO gives the ability to perform 'liftIO' and run IO actions. To
     -- run 'DiscordHandler' actions from within Voice, use
     -- 'Discord.Voice.liftDiscord'.
+    , MonadUnliftIO
+    -- ^ MonadUnliftIO gives us the ability to come back into the monadic
+    -- context from within a lifted IO context. We don't need it in internal
+    -- code, but the instance is provided to make it more convenient for users
+    -- to use e.g. UnliftIO.forkIO from inside Voice without having to manually
+    -- unwrap and capture state.
     , MonadReader DiscordBroadcastHandle
     -- ^ MonadReader is for internal use, to read the held broadcast handle.
     , MonadFail

--- a/src/Discord/Internal/Voice.hs
+++ b/src/Discord/Internal/Voice.hs
@@ -172,6 +172,23 @@ liftDiscord = Voice . lift
 -- (or on the GitHub repository for this library) for a music bot that does
 -- exactly the approach described above.
 --
+-- == Forking
+--
+-- You can also fork and run 'runVoice' in a separate thread, although we don't
+-- provide any helpers or wrappers. An example is given below. The example uses
+-- UnliftIO for convenience of forking from within DiscordHandler, but you could
+-- also manually 'ask' the state from DiscordHandler, lift to IO, use regular
+-- 'Control.Concurrent.forkIO', and run ReaderT again to achieve the same.
+--
+-- @
+-- import qualified UnliftIO.Concurrent as Unlift (forkIO)
+-- func :: DiscordHandler ()
+-- func = do
+--     tid <- Unlift.forkIO $ runVoice $ do
+--         join guildid chanid
+--         forever $ play (createFileResource "music.mp3" Nothing) UnknownCodec
+-- @
+--
 -- == Broadcasting
 --
 -- Within a single use of 'runVoice', the same packets are sent to all


### PR DESCRIPTION
Elaborates on the possibility of using forkIO to run voice actions in another thread to return control flow to the main thread. We also add a MonadUnliftIO instance to the Voice monad so that users can use forkIO from within Voice too, not just from DiscordHandler or IO.