### PR TITLE
Last-minute pre-release fixes on version bounds and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .stack-work/
 dist-newstyle/
+dist-docs/
 *.secret
 *~
 .DS_Store

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,11 +34,12 @@
   - Relax package bounds:
     - `aeson` from ==1.5.6.0 to <2.3
     - `bytestring` from <0.11 to <0.13
-    - `conduit` from <=1.3.4.2 to <=1.4.0.0
+    - `conduit` from <=1.3.4.2 to <1.4.0.0
     - `mtl` from ==2.2.2 to <2.4
     - `saltine` from <0.2 to <0.4
     - `stm` from <2.5.1 to <2.6
     - `text` from <2 to <3
+    - `time` from <=1.13 to <1.15
     - `websockets` from <0.12.8 to <0.14
     - `wuss` from <=1.2 to <2.1
     - `discord-haskell` from <= 1.14.0 to <= 1.17.1
@@ -47,6 +48,7 @@
   - Updated copyright to current year and include contributors where applicable
   - Added link to GitHub Sponsors
   - Updated Haddock for all functions and added examples and usage to many functions
+  - Added upper bound of `<0.5` to microlens and microlens-th
 
 ## 2.3.1 — 2022 July
 

--- a/discord-haskell-voice.cabal
+++ b/discord-haskell-voice.cabal
@@ -52,18 +52,18 @@ library
     , base >=4.7 && <5
     , binary ==0.8.*
     , bytestring >=0.10.12.0 && <0.13
-    , conduit >=1.3.4.2 && <=1.4.0.0
+    , conduit >=1.3.4.2 && <1.4.0.0
     , conduit-extra ==1.3.6
     , discord-haskell >=1.12.0 && <=1.17.1
-    , microlens >=0.4.11.2
-    , microlens-th >=0.4.3.10
+    , microlens >=0.4.11.2 && <0.5
+    , microlens-th >=0.4.3.10 && <0.5
     , mtl <2.4
     , network >=3.1.1.1 && <3.2
     , opus ==0.3.0.0
     , safe-exceptions >=0.1.7.1 && <0.1.8
     , stm >=2.5.0.0 && <=2.6.0.0
     , text >=1.2.4.1 && <3
-    , time >=1.9.3 && <=1.13
+    , time >=1.9.3 && <1.15
     , unliftio >=0.2.18 && <0.3
     , websockets >=0.12.7.2 && <0.14
     , wuss >=1.1.18 && <2.1.0.0


### PR DESCRIPTION
- Add upper bound to microlens dep to satisfy `cabal check`
- Fix instances of `<=` to be `<` in package dependencies for a more exclusive upper bound
- Bump `time` dependency upper bound to <1.15 instead of <=1.13