### PR TITLE
Add note on DAVE encryption being planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ What is not supported:
 - Decrypting audio packets sent from Discord (other people's voices), and
   decoding them to PCM. This isn't particularly well-documented by Discord and
   will thus likely never be supported by this library.
+- End to End Audio Encryption (DAVE protocol) -- this is planned in the near
+  future, but because Haskell doesn't have the required libraries in the
+  ecosystem, it will require us to create lots of FFI bindings to MLS++ and
+  libdave. Development will be prioritised when Discord sets the discontinuation
+  timeline for non-E2E voice calls. 
 
 ## Installation
 


### PR DESCRIPTION
We're planning DAVE encryption but it's going to be a long way until it's done.

This PR adds a note in the README so potential users know the lack of E2E as it currently stands, and the plan to add it soon.