### PR TITLE
Fix macOS CI broken due to disabled llvm@12, bump Ubuntu to 24

### DIFF
--- a/.github/workflows/build_cabal.yml
+++ b/.github/workflows/build_cabal.yml
@@ -42,10 +42,20 @@ jobs:
           # and runs CI on the result.
           fetch-depth: 0
 
-      - name: Install LLVM 12 for 8.10.7 and 9.0.2 on macOS
+      - name: Install LLVM 12 for 8.10.7 and 9.0.2 on macOS (override disabled)
         if: ${{ matrix.os == 'macOS-latest' && (matrix.ghc == '8.10.7' || matrix.ghc == '9.0.2') }}
         run: |
-          brew install llvm@12
+          # Download the llvm@12 formula and patch it to remove the disabled reason
+          brew update
+          brew fetch --formula llvm@12
+          FORMULA_PATH="$(brew --repo homebrew/core)/Formula/llvm@12.rb"
+          if [ ! -f "$FORMULA_PATH" ]; then
+            FORMULA_PATH="$(brew --repo homebrew/core)/Formula/llvm@12.rb"
+          fi
+          # Remove the 'disable!' line
+          sed -i.bak '/^  disable!/d' "$FORMULA_PATH"
+          # Install ignoring the disabled status
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install llvm@12
           echo "OPT=$(brew --prefix llvm@12)/bin/opt" >> "${GITHUB_ENV}"
           echo "LLC=$(brew --prefix llvm@12)/bin/llc" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/build_cabal.yml
+++ b/.github/workflows/build_cabal.yml
@@ -48,9 +48,9 @@ jobs:
           # Download the llvm@12 formula and patch it to remove the disabled reason
           brew update
           brew fetch --formula llvm@12
-          FORMULA_PATH="$(brew --repo homebrew/core)/Formula/llvm@12.rb"
+          FORMULA_PATH="$(brew --repo homebrew/core)/Formula/l/llvm@12.rb"
           if [ ! -f "$FORMULA_PATH" ]; then
-            FORMULA_PATH="$(brew --repo homebrew/core)/Formula/llvm@12.rb"
+            FORMULA_PATH="$(brew --repo homebrew/core)/Formula/l/llvm@12.rb"
           fi
           # Remove the 'disable!' line
           sed -i.bak '/^  disable!/d' "$FORMULA_PATH"

--- a/.github/workflows/build_cabal.yml
+++ b/.github/workflows/build_cabal.yml
@@ -19,15 +19,20 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
-        ghc: ["8.10.7", "9.0.2", "9.2.4"]
+        os: ["ubuntu-24.04"]
+        # Range all supported versions on most common ubuntu OS
+        ghc: ["8.10.7", "9.0.2", "9.2.8", "9.6.7", "9.8.4"]
         include:
-          - os: ubuntu-22.04
-            ghc: "8.10.7"
+          - os: ubuntu-22.04 # one previous ubuntu version
+            ghc: "9.8.4"
           - os: macOS-latest
-            ghc: "8.10.7"
+            ghc: "8.10.7" # oldest supported version
+          - os: macOS-latest
+            ghc: "9.8.4" # LTS
           - os: windows-latest
-            ghc: "8.10.7"
+            ghc: "8.10.7" # oldest supported version
+          - os: windows-latest
+            ghc: "9.8.4" # LTS
       fail-fast: false
     steps:
       - name: checkout


### PR DESCRIPTION
Fixed the macOS 8.10.7 CI being broken because of 8.10.7 requiring llvm < 13 when Homebrew have disabled llvm@12 since the first of July this year. The solution is to override the disabled status in a local copy of the formula, then install from that (hinting to Homebrew that it should prioritise local copies over the Homebrew web API).

Ubuntu 20.04 was also phased out this May, so this PR also bumps the standard Ubuntu cases to run on 24.04. In addition, GHC versions up to Stackage LTS (9.8.4) was added for the standard Ubuntu CI matrix. Once #59 is merged, we can also add 9.10 and 9.12 in the CI at least for the standard Ubuntu matrix.

For Windows and Mac CI (which are supplementary to the ubuntu matrix which tests all supported GHC versions), this PR also adds LTS compilation tests because only running 8.10.7 felt a little outdated. 