### PR TITLE
Remove unnecessary highway package installation in CI

### DIFF
--- a/.github/workflows/build_cabal.yml
+++ b/.github/workflows/build_cabal.yml
@@ -117,11 +117,6 @@ jobs:
         run: |
           brew install libsodium opus
 
-          # Temporary until runner image is updated: actions/runner-images#6364
-          # or until cabal is updated: haskell/cabal#8496
-          # whichever is earlier
-          brew update && brew reinstall highway
-
       # Renovate is configured in renovate.json to tell the CI about the specific
       # version bump using a Git message trailer. So we parse from this and
       # make it so CI for Renovate is forced to use that constraints -- otherwise


### PR DESCRIPTION
On MacOS CI, since 2022 we employed a workaround for https://github.com/actions/runner-images/issues/6364, but it is no longer necessary due to updated base images. Removing it will shorten CI time slightly.